### PR TITLE
add check for a given string in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Perform nagios check over ssh with password.
 Example:
 
 over_ssh_check.py -H example.com -l userslogin -p passw0rd -c '/home/userlogin/check_disk -w 15% -c 10% -W 15% -K 10% -p /dev/sda1'
+
+Optionally, check for the presence of a given string in the output
+with: -s string


### PR DESCRIPTION
This is a small addition to the check, which allows Nagios to alert if the SSH connection is successful, but a given string is not present in the command output.